### PR TITLE
Add Scroll Sepolia to Chainlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # contribute
+
+## Integrations
+- [ethereum-lists/chains](https://github.com/ethereum-lists/chains/)


### PR DESCRIPTION
Closes #1 after merging of [this PR](https://github.com/ethereum-lists/chains/pull/2879).

**Work Completed**

- [x] Add Scroll Sepolia with Sepolia listed as L1 Base Chain
- [x] Update Scroll PreAlpha to be marked as deprecated
- [x] Explicitly label Scroll Alpha and Scroll Mainnet statuses