### PR TITLE
Automatically add label to new issues

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -17,6 +17,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ["triage-new_issue"]
+              labels: ["triage-new-issue"]
             })
 


### PR DESCRIPTION
label `triage-new-issue` is automatically added to any issues that are opened or reopened