### PR TITLE
MetaMask Snap for Calculating L1 Fees

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -8,5 +8,10 @@
     "contribution-title": "Add Scroll to ethereum-multicall",
     "project-repo": "https://github.com/joshstevens19/ethereum-multicall/",
     "contributors": ["omahs"]
+  },
+  {
+    "contribution-title": "A MetaMask Snap for Calculating L1 Fees for Scroll Transactions",
+    "project-repo": "https://github.com/0x4r45h/L2Insights",
+    "contributors": ["0x4r45h"]
   }
 ]


### PR DESCRIPTION
# Checklist ✅
- [x] I've read [CONTRIBUTIONS.md](https://github.com/scroll-tech/contribute-to-scroll/blob/main/CONTRIBUTIONS.md) document
- [x] I've filled the `contributions.json` file

# Issues this PR Resolves 🚀
- Link to the Issue: https://github.com/scroll-tech/contribute-to-scroll/issues/12
- Link to the resolving PR on 3rd party repo: [L2Insights](https://github.com/0x4r45h/L2Insights)

# Contributor social handles (Github / Twitter / Telegram) 🎙️
   - Github: [0x4r45h](https://github.com/0x4r45h)
   - Twitter: [0x4r45h1](https://twitter.com/4r45h1)

# Contribution Description 📝
Right now, MetaMask can only estimate L2 fees and doesn't consider L1 fees. This Snap shows a fee breakdown of
the transaction, including the L1 fee

