### PR TITLE
docs: add GitPOAP section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Thanks for your interest in contributing to Scroll. Check out the [CONTRIBUTING]
 
 ### GitPOAP
 
-Once your pull requests are merged, you will automatically be able to mint  [GitPOAP](https://www.gitpoap.io/gh/scroll-tech/contribute-to-scroll).
+Once your pull request is merged, you will be automatically awared the right to mint a [GitPOAP](https://www.gitpoap.io/gh/scroll-tech/contribute-to-scroll).
 
 1. Go to [GitPOAP](https://www.gitpoap.io/gh/scroll-tech/contribute-to-scroll).
 2. Connect to your wallet or email .

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This repository guides developers wanting to contribute to Scroll. You can start
 
 Thanks for your interest in contributing to Scroll. Check out the [CONTRIBUTING](https://github.com/scroll-tech/contribute/blob/main/CONTRIBUTING.md) page for a guide on how to contribute.
 
+### GitPOAP
+
+Once your pull requests are merged, you will automatically be able to mint  [GitPOAP](https://www.gitpoap.io/gh/scroll-tech/contribute-to-scroll).
+
+1. Go to [GitPOAP](https://www.gitpoap.io/gh/scroll-tech/contribute-to-scroll).
+2. Connect to your wallet or email .
+3. If your GitHub account is eligible, you can mint GitPOAP.
+   
 ## Contributions
 
 ### Integrations


### PR DESCRIPTION
Update REAME by adding how to claim a contribute-to-scroll-GitPOAP 

close https://github.com/scroll-tech/contribute-to-scroll/issues/141

# Checklist ✅
- [✅] I've read [CONTRIBUTIONS.md](https://github.com/scroll-tech/contribute-to-scroll/blob/main/CONTRIBUTIONS.md) document
- [✅] I've filled the `contributions.json` file

